### PR TITLE
added speed bar; fixed closing issue

### DIFF
--- a/slideshow.h
+++ b/slideshow.h
@@ -24,9 +24,11 @@ public:
     void setImageList(QStringList);
     void timerEvent(QTimerEvent*);
     void updateView(cv::Mat);
+    void closeEvent(QCloseEvent*);
 
 public slots:
-    void on_imageSlider_moved(int);
+    void imageSlider_moved(int);
+    void speedSlider_moved(int);
     void on_playButton_clicked();
     void on_pauseButton_clicked();
 
@@ -35,6 +37,7 @@ private:
     QBasicTimer interSlideTimer;
     int slideInterval; //delay time between slides
     int currentSlide;
+    int numSlides; //number of slides
     cv::Mat src;
 
     QStringList imageList;

--- a/slideshow.ui
+++ b/slideshow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>796</width>
-    <height>717</height>
+    <height>748</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,14 +66,62 @@
      <enum>Qt::Horizontal</enum>
     </property>
    </widget>
-   <widget class="QLineEdit" name="vary_lineEdit">
+   <widget class="QLineEdit" name="slideNum_LineEdit">
     <property name="enabled">
-     <bool>false</bool>
+     <bool>true</bool>
     </property>
     <property name="geometry">
      <rect>
       <x>670</x>
       <y>620</y>
+      <width>101</width>
+      <height>31</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QSlider" name="speedSlider">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>660</y>
+      <width>451</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>100</number>
+    </property>
+    <property name="singleStep">
+     <number>10</number>
+    </property>
+    <property name="sliderPosition">
+     <number>50</number>
+    </property>
+    <property name="orientation">
+     <enum>Qt::Horizontal</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>97</x>
+      <y>660</y>
+      <width>91</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Slide speed:</string>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="slideSpeed_LineEdit">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>670</x>
+      <y>650</y>
       <width>101</width>
       <height>31</height>
      </rect>


### PR DESCRIPTION
Speed bar allows manual changing of delay time between slides. Slideshow
would continue to work in the background after the slideshow window was
closed - now fixed.